### PR TITLE
fix: single column layout for wizard buttons on mobile

### DIFF
--- a/app/legacy.css
+++ b/app/legacy.css
@@ -1637,3 +1637,17 @@ textarea {
 }
 
 /*# sourceMappingURL=style.comp.css.map */
+
+/* Wizard grid layout */
+.wizard-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
+  width: 100%;
+  max-width: 50rem;
+}
+@media only screen and (max-width: 37.5em) {
+  .wizard-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/components/wizard/steps/MultiSelectStep.tsx
+++ b/components/wizard/steps/MultiSelectStep.tsx
@@ -31,14 +31,8 @@ export default function MultiSelectStep({ stepId, onNext, currentValue }: Props)
   return (
     <div className="buttons" style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
       <div
-        style={useGrid ? {
-          display: "grid",
-          gridTemplateColumns: "repeat(2, 1fr)",
-          gap: "2rem",
-          width: "100%",
-          maxWidth: "50rem",
-          marginBottom: "2rem",
-        } : undefined}
+        className={useGrid ? "wizard-grid" : undefined}
+        style={{ marginBottom: "2rem" }}
       >
         {options.map((option, index) => (
           <button

--- a/components/wizard/steps/SingleSelectStep.tsx
+++ b/components/wizard/steps/SingleSelectStep.tsx
@@ -15,14 +15,7 @@ export default function SingleSelectStep({ stepId, onNext, currentValue }: Props
 
   return (
     <div
-      className="buttons"
-      style={useGrid ? {
-        display: "grid",
-        gridTemplateColumns: "repeat(2, 1fr)",
-        gap: "2rem",
-        width: "100%",
-        maxWidth: "50rem",
-      } : undefined}
+      className={useGrid ? "wizard-grid" : "buttons"}
     >
       {options.map((option, index) => (
         <button


### PR DESCRIPTION
- Added .wizard-grid CSS class with responsive breakpoint
- 2 columns on desktop (≥600px), 1 column on mobile (<600px)
- Applied to both SingleSelectStep and MultiSelectStep